### PR TITLE
refactor: add support for new abstractions at the workspace level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/ui",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "license": "MIT",
   "description": "Hoppscotch UI",
   "author": "Hoppscotch (support@hoppscotch.io)",

--- a/src/components/smart/Tree.vue
+++ b/src/components/smart/Tree.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script setup lang="ts" generic="T extends any">
-import { computed, inject } from "vue"
+import { inject } from "vue"
 import SmartTreeBranch from "./TreeBranch.vue"
 import SmartSpinner from "./Spinner.vue"
 import { SmartTreeAdapter, TreeNode } from "~/helpers/treeAdapter"
@@ -68,5 +68,5 @@ const props = defineProps<{
 /**
  * Fetch the root nodes from the adapter by passing the node id as null
  */
-const rootNodes = computed(() => props.adapter.getChildren(null).value)
+const rootNodes = props.adapter.getChildren(null)
 </script>

--- a/src/components/smart/TreeBranch.vue
+++ b/src/components/smart/TreeBranch.vue
@@ -27,7 +27,7 @@
     >
       <SmartTreeBranch
         v-for="childNode in childNodes.data"
-        :key="childNode.id"
+        :key="`${childNode.id}-${childNode.data.type}`"
         :node-item="childNode"
         :adapter="adapter"
       >
@@ -114,9 +114,7 @@ const highlightNode = ref(false)
 /**
  * Fetch the child nodes from the adapter by passing the node id of the current node
  */
-const childNodes = computed(
-  () => props.adapter.getChildren(props.nodeItem.id).value,
-)
+const childNodes = props.adapter.getChildren(props.nodeItem.id, props.nodeItem.data.type)
 
 const toggleNodeChildren = () => {
   if (!childrenRendered.value) childrenRendered.value = true

--- a/src/helpers/treeAdapter.ts
+++ b/src/helpers/treeAdapter.ts
@@ -28,7 +28,8 @@ export interface SmartTreeAdapter<T> {
   /**
    *
    * @param nodeID - id of the node to get children for
+   * @param nodeType - Type of the node (`collection` | `request`)
    * @returns - Ref that contains the children of the node. It is reactive and will be updated when the children are changed.
    */
-  getChildren: (nodeID: string | null) => Ref<ChildrenResult<T>>
+  getChildren: (nodeID: string | null, nodeType?: string) => Ref<ChildrenResult<T>>
 }


### PR DESCRIPTION
This PR brings about changes to support the new abstractions at the workspace level that are in the works - https://github.com/hoppscotch/hoppscotch/pull/3836.

- `rootNodes` & `childNodes` in `Tree` & `TreeBranch` components are no longer computed properties. Since a handle-based system is introduced which leverages reactivity greatly, this is necessary to prevent any UI freeze while switching between workspaces.
- Update the `key` prop while rendering the `SmartTreeBranch` component within the same component to include node data type and ID. This ensures the UI stays consistent with the underlying state changes and necessary rerenders get triggered.
- Adds a new optional parameter to the `getChildren` method `nodeType` (need not be supplied for root nodes, hence optional) to distinguish between the incoming node types. This helps tree adapter implementations avoid performing operations specific to collections in case the incoming node is a request.

Closes HFE-506.