### PR TITLE
Disabling keypress action on primary button loading state

### DIFF
--- a/src/components/button/Primary.vue
+++ b/src/components/button/Primary.vue
@@ -108,9 +108,7 @@ const props = withDefaults(defineProps<Props>(), {
 const handleKeypress = (event: KeyboardEvent) => {
   // Check if the button is in a loading state
   if (props.loading && (event.key === "Enter" || event.key === " ")){
-    event.preventDefault(); // Prevent keypresses when loading
-  } else {
-    console.log('Enter succeeds as normal')
+    event.preventDefault();
   }
 };
 </script>

--- a/src/components/button/Primary.vue
+++ b/src/components/button/Primary.vue
@@ -26,6 +26,7 @@
     :disabled="disabled"
     :tabindex="loading ? '-1' : '0'"
     role="button"
+    @keydown="handleKeypress"
   >
     <span
       class="inline-flex items-center justify-center whitespace-nowrap"
@@ -85,7 +86,7 @@ interface Props {
   shortcut?: string[]
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   to: "",
   exact: true,
   blank: false,
@@ -103,4 +104,13 @@ withDefaults(defineProps<Props>(), {
   outline: false,
   shortcut: () => [],
 })
+
+const handleKeypress = (event: KeyboardEvent) => {
+  // Check if the button is in a loading state
+  if (props.loading && (event.key === "Enter" || event.key === " ")){
+    event.preventDefault(); // Prevent keypresses when loading
+  } else {
+    console.log('Enter succeeds as normal')
+  }
+};
 </script>

--- a/src/stories/Button.story.vue
+++ b/src/stories/Button.story.vue
@@ -1,14 +1,69 @@
 <template>
   <Story title="Button">
     <Variant title="Primary">
-      <HoppButtonPrimary label="Button" />
+      <HoppButtonPrimary 
+        ref="primaryButton"
+        label="Button" 
+        @click="handleClick('Primary button clicked')" 
+      />
     </Variant>
     <Variant title="Secondary">
-      <HoppButtonSecondary label="Button" />
+      <HoppButtonSecondary 
+        label="Button" 
+        :loading="isLoading"
+        @click="handleClick('Secondary button clicked')" 
+      />
     </Variant>
   </Story>
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { HoppButtonPrimary, HoppButtonSecondary } from "../components/button"
+
+const primaryButton = ref<InstanceType<typeof HoppButtonPrimary> | null>(null);
+const isLoading = ref(false);
+
+// Function to handle click event, log message, and trigger an Enter keypress event
+function handleClick(message: string) {
+  console.log(message)
+
+    // Set loading state to true
+  isLoading.value = true;
+
+  // Simulate loading by resetting the loading state after 3 seconds
+  setTimeout(() => {
+  isLoading.value = false;
+}, 3000); // 3 seconds delay
+}
+
+function handleKeyPress(event: KeyboardEvent) {
+
+  const enterEvent = new KeyboardEvent('keydown', {
+    key: ' ',
+    code: ' ',
+    keyCode: 32, 
+    charCode: 32,
+    which: 32,
+    bubbles: true, 
+  });
+
+  // Dispatch the Enter keypress event on the HoppButtonPrimary element
+  if (primaryButton.value) {
+    primaryButton.value.$el.dispatchEvent(enterEvent); // Trigger the event on the button
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', (event: KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      handleKeyPress(event);
+    }
+  });
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', handleKeyPress)
+})
+
 </script>

--- a/src/stories/Button.story.vue
+++ b/src/stories/Button.story.vue
@@ -1,69 +1,14 @@
 <template>
   <Story title="Button">
     <Variant title="Primary">
-      <HoppButtonPrimary 
-        ref="primaryButton"
-        label="Button" 
-        @click="handleClick('Primary button clicked')" 
-      />
+      <HoppButtonPrimary label="Button" />
     </Variant>
     <Variant title="Secondary">
-      <HoppButtonSecondary 
-        label="Button" 
-        :loading="isLoading"
-        @click="handleClick('Secondary button clicked')" 
-      />
+      <HoppButtonSecondary label="Button" />
     </Variant>
   </Story>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { HoppButtonPrimary, HoppButtonSecondary } from "../components/button"
-
-const primaryButton = ref<InstanceType<typeof HoppButtonPrimary> | null>(null);
-const isLoading = ref(false);
-
-// Function to handle click event, log message, and trigger an Enter keypress event
-function handleClick(message: string) {
-  console.log(message)
-
-    // Set loading state to true
-  isLoading.value = true;
-
-  // Simulate loading by resetting the loading state after 3 seconds
-  setTimeout(() => {
-  isLoading.value = false;
-}, 3000); // 3 seconds delay
-}
-
-function handleKeyPress(event: KeyboardEvent) {
-
-  const enterEvent = new KeyboardEvent('keydown', {
-    key: ' ',
-    code: ' ',
-    keyCode: 32, 
-    charCode: 32,
-    which: 32,
-    bubbles: true, 
-  });
-
-  // Dispatch the Enter keypress event on the HoppButtonPrimary element
-  if (primaryButton.value) {
-    primaryButton.value.$el.dispatchEvent(enterEvent); // Trigger the event on the button
-  }
-}
-
-onMounted(() => {
-  document.addEventListener('keydown', (event: KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      handleKeyPress(event);
-    }
-  });
-})
-
-onBeforeUnmount(() => {
-  document.removeEventListener('keydown', handleKeyPress)
-})
-
 </script>

--- a/src/stories/Keypress.story.vue
+++ b/src/stories/Keypress.story.vue
@@ -1,0 +1,70 @@
+<template>
+    <Story title="Button">
+      <Variant title="Primary">
+        <HoppButtonPrimary 
+          ref="primaryButton"
+          label="Button" 
+          @click="handleClick('Primary button clicked')" 
+        />
+      </Variant>
+      <Variant title="Secondary">
+        <HoppButtonSecondary 
+          label="Button" 
+          :loading="isLoading"
+          @click="handleClick('Secondary button clicked')" 
+        />
+      </Variant>
+    </Story>
+  </template>
+  
+  <script setup lang="ts">
+  import { ref, onMounted, onBeforeUnmount } from 'vue'
+  import { HoppButtonPrimary, HoppButtonSecondary } from "../components/button"
+  
+  const primaryButton = ref<InstanceType<typeof HoppButtonPrimary> | null>(null);
+  const isLoading = ref(false);
+  
+  // Function to handle click event, log message, and trigger an Enter keypress event
+  function handleClick(message: string) {
+    console.log(message)
+  
+      // Set loading state to true
+    isLoading.value = true;
+  
+    // Simulate loading by resetting the loading state after 3 seconds
+    setTimeout(() => {
+    isLoading.value = false;
+  }, 3000); // 3 seconds delay
+  }
+  
+  function handleKeyPress(event: KeyboardEvent) {
+  
+    const enterEvent = new KeyboardEvent('keydown', {
+      key: ' ',
+      code: ' ',
+      keyCode: 32, 
+      charCode: 32,
+      which: 32,
+      bubbles: true, 
+    });
+  
+    // Dispatch the Enter keypress event on the HoppButtonPrimary element
+    if (primaryButton.value) {
+      primaryButton.value.$el.dispatchEvent(enterEvent); // Trigger the event on the button
+    }
+  }
+  
+  onMounted(() => {
+    document.addEventListener('keydown', (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        handleKeyPress(event);
+      }
+    });
+  })
+  
+  onBeforeUnmount(() => {
+    document.removeEventListener('keydown', handleKeyPress)
+  })
+  
+  </script>
+  


### PR DESCRIPTION
This PR extends the disabled click action to the "Enter" and "Space" keypress during loading state. This is to address the multiple request issue https://github.com/hoppscotch/hoppscotch/issues/4134 in the hoppscotch repository.  

**What's Changed**
- Added a key event listener to HoppButtonPrimary.
- Added a HandleKeypress function that disables the enter and space eventf if the button is loading
- Added a "Keypress" story so that other developers can test the functionality of the new changes

I confirmed that both keypress actions are disabled during loading state on Histoire using the new story. 
Here is a test video:


https://github.com/user-attachments/assets/7bef60cc-9571-4ee3-b36b-cb9701515460


