### PR TITLE
feat: enhance⁠ `Tree` component capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/ui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "description": "Hoppscotch UI",
   "author": "Hoppscotch (support@hoppscotch.io)",

--- a/src/components/smart/Checkbox.vue
+++ b/src/components/smart/Checkbox.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="inline-flex items-center justify-center cursor-pointer group flex-nowrap transition hover:text-secondaryDark"
+    class="group inline-flex cursor-pointer flex-nowrap items-center justify-center transition hover:text-secondaryDark"
     role="checkbox"
     :aria-checked="on"
     @click="emit('change')"
@@ -15,7 +15,7 @@
     />
     <label
       :for="checkboxID"
-      class="pl-0 font-semibold truncate align-middle cursor-pointer"
+      class="cursor-pointer truncate pl-0 align-middle font-semibold"
     >
       <slot></slot>
     </label>
@@ -36,16 +36,16 @@ let checkboxIDCounter = 564275
 <script setup lang="ts">
 // Unique ID for checkbox
 const checkboxID = `checkbox-${checkboxIDCounter++}`
-defineProps({
-  on: {
-    type: Boolean,
-    default: false,
+withDefaults(
+  defineProps<{
+    on: boolean
+    name: string
+  }>(),
+  {
+    on: false,
+    name: "checkbox",
   },
-  name: {
-    type: String,
-    default: "checkbox",
-  },
-})
+)
 
 const emit = defineEmits<{
   (e: "change"): void

--- a/src/components/smart/Tree.vue
+++ b/src/components/smart/Tree.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col flex-1">
+  <div class="flex flex-1 flex-col">
     <div
       v-if="rootNodes.status === 'loaded' && rootNodes.data.length > 0"
       class="flex flex-col"
@@ -7,11 +7,12 @@
       <div
         v-for="rootNode in rootNodes.data"
         :key="rootNode.id"
-        class="flex flex-col flex-1"
+        class="flex flex-1 flex-col"
       >
         <SmartTreeBranch
           :root-nodes-length="rootNodes.data.length"
           :node-item="rootNode"
+          :expand-all="expandAll"
           :adapter="adapter as SmartTreeAdapter<T>"
         >
           <template
@@ -34,14 +35,14 @@
     </div>
     <div
       v-else-if="rootNodes.status === 'loading'"
-      class="flex flex-col items-center justify-center flex-1 p-4"
+      class="flex flex-1 flex-col items-center justify-center p-4"
     >
       <SmartSpinner class="my-4" />
       <span class="text-secondaryLight">{{ t?.("state.loading") }}</span>
     </div>
     <div
       v-if="rootNodes.status === 'loaded' && rootNodes.data.length === 0"
-      class="flex flex-col flex-1"
+      class="flex flex-1 flex-col"
     >
       <!-- eslint-disable-next-line vue/no-deprecated-filter -->
       <slot name="emptyNode" :node="null as TreeNode<T> | null"></slot>
@@ -63,6 +64,10 @@ const props = defineProps<{
    * @template T The type of the data that will be stored in the tree
    */
   adapter: SmartTreeAdapter<T>
+  /**
+   *  open by default
+   */
+  expandAll?: boolean
 }>()
 
 /**


### PR DESCRIPTION
This PR introduces support for expanding and collapsing nodes in the ⁠Tree component.

Changes:
	•	Added ⁠`expand-all` prop: This boolean prop allows developers to control the initial expanded state of a node.