### PR TITLE
fix: Checkbox component firing multiple change event

### DIFF
--- a/src/components/smart/Checkbox.vue
+++ b/src/components/smart/Checkbox.vue
@@ -3,7 +3,6 @@
     class="group inline-flex cursor-pointer flex-nowrap items-center justify-center transition hover:text-secondaryDark"
     role="checkbox"
     :aria-checked="on"
-    @click="emit('change')"
   >
     <input
       :id="checkboxID"


### PR DESCRIPTION
**Before**

Previously the Checkbox component had multiple `change` event triggers setup, this was causing multiple events getting fired when using the component.

**After**

The trigger on click on the wrapper div is removed. the input @change event will properly fire for both the input & label clicks.