### PR TITLE
fix: improve primary button loading behavior

### DIFF
--- a/src/components/button/Primary.vue
+++ b/src/components/button/Primary.vue
@@ -2,7 +2,7 @@
   <HoppSmartLink
     :to="to"
     :blank="blank"
-    class="relative inline-flex items-center justify-center py-2 font-semibold whitespace-nowrap transition focus:outline-none focus-visible:bg-accentDark"
+    class="relative inline-flex items-center justify-center whitespace-nowrap py-2 font-semibold transition focus:outline-none focus-visible:bg-accentDark"
     :exact="exact"
     :class="[
       color
@@ -40,7 +40,7 @@
           label ? (reverse ? 'ml-2' : 'mr-2') : '',
         ]"
       />
-      <div class="max-w-[16rem] truncate">
+      <div class="max-w-[16rem] truncate" :class="[{ invisible: loading }]">
         {{ label }}
       </div>
       <div v-if="shortcut.length" class="<sm:hidden">


### PR DESCRIPTION
## Fixes Issue
Closes #36
## Description
The button label's visibility is now conditionally controlled. It is hidden while the loader is in a true state.

## Screenshots
[Screencast from 2025-05-01 20-05-41.webm](https://github.com/user-attachments/assets/f86ac237-fa4b-4b00-8438-df2fb9359fbe)
