### PR TITLE
feat: add indicator variants and order hint to `HoppSmartTab`

### DIFF
--- a/src/assets/scss/themes.scss
+++ b/src/assets/scss/themes.scss
@@ -44,11 +44,10 @@
   --popover-color: #1b1b1b;
   --editor-theme: "merbivore_soft";
 
-  // Semantic feedback colors for inline UI signals (e.g. the tab indicator dot).
-  // ui-preset's error/warning/success/info tokens read these. Prefixed
-  // `--feedback-*` so they don't collide with the platform's `--status-*` (HTTP
-  // response colors), `--method-*`, or the `--error-color` neutral. hopp-ui is
-  // dark-only, so these are Tailwind's 500 shades with no light-tuned set.
+  // Semantic feedback colors for inline UI signals (e.g. the tab indicator dot),
+  // read by ui-preset's error/warning/success/info tokens. The `--feedback-*`
+  // prefix avoids colliding with the platform's `--status-*`, `--method-*`, and
+  // `--error-color` vars. @hoppscotch/ui is dark-only — Tailwind's 500 shades.
   --feedback-error-color: #ef4444; // red-500
   --feedback-warning-color: #f59e0b; // amber-500
   --feedback-success-color: #22c55e; // green-500

--- a/src/assets/scss/themes.scss
+++ b/src/assets/scss/themes.scss
@@ -43,6 +43,16 @@
   --tooltip-color: #f5f5f5;
   --popover-color: #1b1b1b;
   --editor-theme: "merbivore_soft";
+
+  // Semantic feedback colors for inline UI signals (e.g. the tab indicator dot).
+  // ui-preset's error/warning/success/info tokens read these. Prefixed
+  // `--feedback-*` so they don't collide with the platform's `--status-*` (HTTP
+  // response colors), `--method-*`, or the `--error-color` neutral. hopp-ui is
+  // dark-only, so these are Tailwind's 500 shades with no light-tuned set.
+  --feedback-error-color: #ef4444; // red-500
+  --feedback-warning-color: #f59e0b; // amber-500
+  --feedback-success-color: #22c55e; // green-500
+  --feedback-info-color: #3b82f6; // blue-500
 }
 
 @mixin green-theme {

--- a/src/assets/scss/themes.scss
+++ b/src/assets/scss/themes.scss
@@ -45,9 +45,8 @@
   --editor-theme: "merbivore_soft";
 
   // Semantic feedback colors for inline UI signals (e.g. the tab indicator dot),
-  // read by ui-preset's error/warning/success/info tokens. The `--feedback-*`
-  // prefix avoids colliding with the platform's `--status-*`, `--method-*`, and
-  // `--error-color` vars. @hoppscotch/ui is dark-only — Tailwind's 500 shades.
+  // surfaced by ui-preset's error/warning/success/info tokens. The `--feedback-*`
+  // prefix avoids colliding with the platform's `--status-*` / `--method-*` / `--error-color`.
   --feedback-error-color: #ef4444; // red-500
   --feedback-warning-color: #f59e0b; // amber-500
   --feedback-success-color: #22c55e; // green-500

--- a/src/components/smart/Tab.vue
+++ b/src/components/smart/Tab.vue
@@ -5,16 +5,9 @@
 </template>
 
 <script setup lang="ts">
-import {
-  onMounted,
-  onBeforeUnmount,
-  inject,
-  computed,
-  watch,
-  Component,
-  markRaw,
-} from "vue"
-import { TabMeta, TabProvider, IndicatorVariant } from "./Tabs.vue"
+import { onMounted, onBeforeUnmount, inject, computed, watch, markRaw } from "vue"
+import type { Component } from "vue"
+import type { TabMeta, TabProvider, IndicatorVariant } from "./Tabs.vue"
 
 const props = withDefaults(
   defineProps<{

--- a/src/components/smart/Tab.vue
+++ b/src/components/smart/Tab.vue
@@ -16,19 +16,13 @@ const props = withDefaults(
     icon?: Component | object | string | null
     info?: string | null
     indicator?: boolean
-    /**
-     * Color of the indicator dot. `"accent"` (default) is neutral activity; the
-     * semantic variants (`"error"`, `"warning"`, `"success"`, `"info"`) let
-     * consumers flag a tab's state without reaching into the dot's internal
-     * classes via `:deep()`.
-     */
+    /** Color of the indicator dot; defaults to `"accent"`. */
     indicatorVariant?: IndicatorVariant
     disabled?: boolean
     alignLast?: boolean
     /**
-     * Display-order hint. Lower numbers render first; ties resolve by
-     * registration order. Useful for tabs that toggle in/out via `v-if`
-     * but should still appear in a fixed position when present.
+     * Render-order hint; lower renders first (ties keep registration order).
+     * Lets `v-if`-toggled tabs hold a fixed position.
      */
     order?: number
   }>(),

--- a/src/components/smart/Tab.vue
+++ b/src/components/smart/Tab.vue
@@ -14,7 +14,7 @@ import {
   Component,
   markRaw,
 } from "vue"
-import { TabMeta, TabProvider } from "./Tabs.vue"
+import { TabMeta, TabProvider, IndicatorVariant } from "./Tabs.vue"
 
 const props = withDefaults(
   defineProps<{
@@ -23,15 +23,30 @@ const props = withDefaults(
     icon?: Component | object | string | null
     info?: string | null
     indicator?: boolean
+    /**
+     * Color of the indicator dot. `"accent"` (default) is neutral activity; the
+     * semantic variants (`"error"`, `"warning"`, `"success"`, `"info"`) let
+     * consumers flag a tab's state without reaching into the dot's internal
+     * classes via `:deep()`.
+     */
+    indicatorVariant?: IndicatorVariant
     disabled?: boolean
     alignLast?: boolean
+    /**
+     * Display-order hint. Lower numbers render first; ties resolve by
+     * registration order. Useful for tabs that toggle in/out via `v-if`
+     * but should still appear in a fixed position when present.
+     */
+    order?: number
   }>(),
   {
     icon: null,
     indicator: false,
+    indicatorVariant: "accent",
     info: null,
     disabled: false,
     alignLast: false,
+    order: 0,
   },
 )
 
@@ -43,10 +58,12 @@ const tabMeta = computed<TabMeta>(() => ({
       : props.icon,
 
   indicator: props.indicator,
+  indicatorVariant: props.indicatorVariant,
   info: props.info,
   label: props.label,
   disabled: props.disabled,
   alignLast: props.alignLast,
+  order: props.order,
 }))
 
 const {

--- a/src/components/smart/Tabs.vue
+++ b/src/components/smart/Tabs.vue
@@ -234,16 +234,24 @@ onBeforeUnmount(() => {
   isUnmounting.value = true
 })
 
-// Maps each indicator variant to its dot color. Literal class strings (not
-// interpolated) so Tailwind's JIT compiles them into the shipped stylesheet.
-const indicatorDotClass = (variant: IndicatorVariant = "accent"): string =>
-  ({
-    accent: "bg-accentLight",
-    error: "bg-error",
-    warning: "bg-warning",
-    success: "bg-success",
-    info: "bg-info",
-  })[variant]
+// Maps each indicator variant to its dot color. Hoisted out of the lookup
+// function so it isn't reallocated on every render; typed
+// `Record<IndicatorVariant, string>` so extending the union forces a matching
+// entry here. Literal class strings (not interpolated) so Tailwind's JIT
+// compiles them into the shipped stylesheet.
+const INDICATOR_DOT_CLASSES: Record<IndicatorVariant, string> = {
+  accent: "bg-accentLight",
+  error: "bg-error",
+  warning: "bg-warning",
+  success: "bg-success",
+  info: "bg-info",
+}
+
+// Falls back to the accent class for an undefined or — since Vue doesn't enforce
+// the TS union at runtime — unrecognized `variant`, so the dot always renders a
+// visible color instead of silently dropping the class.
+const indicatorDotClass = (variant?: IndicatorVariant): string =>
+  INDICATOR_DOT_CLASSES[variant ?? "accent"] ?? INDICATOR_DOT_CLASSES.accent
 
 const selectTab = (id: string) => {
   emit("update:modelValue", id)

--- a/src/components/smart/Tabs.vue
+++ b/src/components/smart/Tabs.vue
@@ -24,8 +24,8 @@
               }"
             >
               <button
-                v-for="([tabID, tabMeta], index) in tabGroup"
-                :key="`tab-${index}`"
+                v-for="[tabID, tabMeta] in tabGroup"
+                :key="tabID"
                 v-tippy="{
                   theme: 'tooltip',
                   placement: 'left',
@@ -91,8 +91,8 @@ import { pipe } from "fp-ts/function"
 import { not } from "fp-ts/Predicate"
 import * as A from "fp-ts/Array"
 import * as O from "fp-ts/Option"
-import type { Component, Ref } from "vue"
-import { ref, ComputedRef, computed, provide, onBeforeUnmount } from "vue"
+import type { Component, ComputedRef, Ref } from "vue"
+import { ref, computed, provide, onBeforeUnmount } from "vue"
 
 /**
  * Color of the indicator dot. `"accent"` (default) is neutral activity; the
@@ -165,6 +165,13 @@ const throwError = (message: string): never => {
 
 const tabEntries = ref<Array<[string, TabMeta]>>([])
 
+// Resolves a tab's sort weight. `order` is typed `number`, but Vue won't stop a
+// consumer binding a non-finite value at runtime; coerce NaN/±Infinity/undefined
+// to 0 so the comparator stays well-ordered and the registration-index tiebreak
+// still applies.
+const orderOf = (meta: TabMeta): number =>
+  Number.isFinite(meta.order) ? (meta.order as number) : 0
+
 // Tab related logic — render order respects `tabMeta.order` as a primary
 // sort key, with registration order as a stable tiebreaker. This lets
 // consumers pin a tab to a specific position regardless of when it mounts
@@ -174,7 +181,7 @@ const alignedTabs = computed(() => {
     (entry, idx) => [entry, idx] as [[string, TabMeta], number],
   )
   indexed.sort(([[, a], aIdx], [[, b], bIdx]) => {
-    const delta = (a.order ?? 0) - (b.order ?? 0)
+    const delta = orderOf(a) - orderOf(b)
     return delta !== 0 ? delta : aIdx - bIdx
   })
   const sorted = indexed.map(([entry]) => entry)
@@ -214,9 +221,18 @@ const removeTabEntry = (tabID: string) => {
     O.getOrElseW(() => throwError(`Failed to remove tab entry: ${tabID}`)),
   )
 
-  // If we tried to remove the active tabEntries, switch to first tab entry
-  if (props.modelValue === tabID)
-    if (tabEntries.value.length > 0) selectTab(tabEntries.value[0][0])
+  // If we removed the active tab, fall back to the first *enabled* tab in
+  // render order (left group before right), read from the same `alignedTabs`
+  // computed that drives the template — so the choice matches what the user
+  // sees once `order`/`alignLast` reshuffle the bar, and we never silently
+  // activate a disabled tab. If every remaining tab is disabled, fall back to
+  // the first one anyway: a valid (if disabled) active id still beats one left
+  // pointing at the just-removed tab.
+  if (props.modelValue === tabID) {
+    const ordered = [...alignedTabs.value.left, ...alignedTabs.value.right]
+    const next = ordered.find(([, meta]) => !meta.disabled) ?? ordered[0]
+    if (next) selectTab(next[0])
+  }
 }
 
 const isUnmounting = ref(false)

--- a/src/components/smart/Tabs.vue
+++ b/src/components/smart/Tabs.vue
@@ -60,7 +60,8 @@
                 </span>
                 <span
                   v-if="tabMeta.indicator"
-                  class="ml-2 h-1 w-1 rounded-full bg-accentLight"
+                  class="ml-2 h-1 w-1 rounded-full"
+                  :class="indicatorDotClass(tabMeta.indicatorVariant)"
                 ></span>
               </button>
             </div>
@@ -93,13 +94,32 @@ import * as O from "fp-ts/Option"
 import type { Component, Ref } from "vue"
 import { ref, ComputedRef, computed, provide, onBeforeUnmount } from "vue"
 
+/**
+ * Color of the indicator dot. `"accent"` (default) is neutral activity; the
+ * semantic variants map to feedback colors (e.g. `"error"` flags a tab that
+ * needs attention). Optional/undefined falls back to accent for older consumers.
+ */
+export type IndicatorVariant = "accent" | "error" | "warning" | "success" | "info"
+
 export type TabMeta = {
   label: string | null
   icon: string | Component | null
   indicator: boolean
+  indicatorVariant?: IndicatorVariant
   info: string | null
   disabled: boolean
   alignLast: boolean
+  /**
+   * Display-order hint. Lower numbers render earlier. Defaults to 0 so the
+   * sort is stable in registration order for tabs that don't opt in.
+   * Lets consumers pin certain tabs (e.g. workspace-mode-specific tabs
+   * that appear/disappear via v-if) to a fixed position without relying
+   * on the order in which Vue mounts them.
+   *
+   * Optional for backward compatibility — older `<HoppSmartTab>` consumers
+   * that predate this field still work; the sort treats `undefined` as 0.
+   */
+  order?: number
 }
 
 export type TabProvider = {
@@ -145,10 +165,21 @@ const throwError = (message: string): never => {
 
 const tabEntries = ref<Array<[string, TabMeta]>>([])
 
-// Tab related logic
+// Tab related logic — render order respects `tabMeta.order` as a primary
+// sort key, with registration order as a stable tiebreaker. This lets
+// consumers pin a tab to a specific position regardless of when it mounts
+// (e.g. tabs gated behind `v-if` that toggle in and out at runtime).
 const alignedTabs = computed(() => {
-  const leftTabs = tabEntries.value.filter(([_, tabMeta]) => !tabMeta.alignLast)
-  const rightTabs = tabEntries.value.filter(([_, tabMeta]) => tabMeta.alignLast)
+  const indexed = tabEntries.value.map(
+    (entry, idx) => [entry, idx] as [[string, TabMeta], number],
+  )
+  indexed.sort(([[, a], aIdx], [[, b], bIdx]) => {
+    const delta = (a.order ?? 0) - (b.order ?? 0)
+    return delta !== 0 ? delta : aIdx - bIdx
+  })
+  const sorted = indexed.map(([entry]) => entry)
+  const leftTabs = sorted.filter(([_, tabMeta]) => !tabMeta.alignLast)
+  const rightTabs = sorted.filter(([_, tabMeta]) => tabMeta.alignLast)
   return { left: leftTabs, right: rightTabs }
 })
 
@@ -202,6 +233,17 @@ provide<TabProvider>("tabs-system", {
 onBeforeUnmount(() => {
   isUnmounting.value = true
 })
+
+// Maps each indicator variant to its dot color. Literal class strings (not
+// interpolated) so Tailwind's JIT compiles them into the shipped stylesheet.
+const indicatorDotClass = (variant: IndicatorVariant = "accent"): string =>
+  ({
+    accent: "bg-accentLight",
+    error: "bg-error",
+    warning: "bg-warning",
+    success: "bg-success",
+    info: "bg-info",
+  })[variant]
 
 const selectTab = (id: string) => {
   emit("update:modelValue", id)

--- a/src/components/smart/Tabs.vue
+++ b/src/components/smart/Tabs.vue
@@ -94,11 +94,7 @@ import * as O from "fp-ts/Option"
 import type { Component, ComputedRef, Ref } from "vue"
 import { ref, computed, provide, onBeforeUnmount } from "vue"
 
-/**
- * Color of the indicator dot. `"accent"` (default) is neutral activity; the
- * semantic variants map to feedback colors (e.g. `"error"` flags a tab that
- * needs attention). Optional/undefined falls back to accent for older consumers.
- */
+/** Color of the indicator dot; defaults to `"accent"`. */
 export type IndicatorVariant =
   | "accent"
   | "error"
@@ -114,16 +110,7 @@ export type TabMeta = {
   info: string | null
   disabled: boolean
   alignLast: boolean
-  /**
-   * Display-order hint. Lower numbers render earlier. Defaults to 0 so the
-   * sort is stable in registration order for tabs that don't opt in.
-   * Lets consumers pin certain tabs (e.g. workspace-mode-specific tabs
-   * that appear/disappear via v-if) to a fixed position without relying
-   * on the order in which Vue mounts them.
-   *
-   * Optional for backward compatibility — older `<HoppSmartTab>` consumers
-   * that predate this field still work; the sort treats `undefined` as 0.
-   */
+  /** Display-order hint; lower renders earlier (default 0). */
   order?: number
 }
 
@@ -170,13 +157,9 @@ const throwError = (message: string): never => {
 
 const tabEntries = ref<Array<[string, TabMeta]>>([])
 
-// Resolves a tab's sort weight. `order` is typed `number`, but Vue won't stop a
-// consumer passing `order="1"` (a string, an easy slip for `:order="1"`), so we
-// coerce number/string inputs via `Number()`. Everything else hits the early
-// `typeof` guard and maps to 0 without calling `Number()` — covering `undefined`
-// (the unset default) and `Symbol`, whose `Number()` conversion throws. Numeric
-// inputs that coerce to non-finite (non-numeric strings, NaN, ±Infinity) also
-// map to 0, keeping the comparator well-ordered with its index tiebreak.
+// Resolves a tab's sort weight, coercing string `order` (e.g. `order="1"`) via
+// `Number()`. The `typeof` guard maps `undefined`/`Symbol` to 0 *before* calling
+// `Number()` (`Number(Symbol())` throws); non-finite coercions fall to 0 too.
 const orderOf = (meta: TabMeta): number => {
   const raw = meta.order
   if (typeof raw !== "number" && typeof raw !== "string") return 0
@@ -184,10 +167,7 @@ const orderOf = (meta: TabMeta): number => {
   return Number.isFinite(n) ? n : 0
 }
 
-// Tab related logic — render order respects `tabMeta.order` as a primary
-// sort key, with registration order as a stable tiebreaker. This lets
-// consumers pin a tab to a specific position regardless of when it mounts
-// (e.g. tabs gated behind `v-if` that toggle in and out at runtime).
+// Render order: `order` ascending, then registration index as a stable tiebreak.
 const alignedTabs = computed(() => {
   const indexed = tabEntries.value.map(
     (entry, idx) => [entry, idx] as [[string, TabMeta], number],
@@ -233,13 +213,9 @@ const removeTabEntry = (tabID: string) => {
     O.getOrElseW(() => throwError(`Failed to remove tab entry: ${tabID}`)),
   )
 
-  // If we removed the active tab, fall back to the first *enabled* tab in
-  // render order (left group before right), read from the same `alignedTabs`
-  // computed that drives the template — so the choice matches what the user
-  // sees once `order`/`alignLast` reshuffle the bar, and we never silently
-  // activate a disabled tab. If every remaining tab is disabled, fall back to
-  // the first one anyway: a valid (if disabled) active id still beats one left
-  // pointing at the just-removed tab.
+  // If the active tab was removed, activate the first *enabled* tab in render
+  // order (from `alignedTabs`, matching the template); if all are disabled, take
+  // the first anyway so the active id never points at the just-removed tab.
   if (props.modelValue === tabID) {
     const ordered = [...alignedTabs.value.left, ...alignedTabs.value.right]
     const next = ordered.find(([, meta]) => !meta.disabled) ?? ordered[0]
@@ -262,11 +238,8 @@ onBeforeUnmount(() => {
   isUnmounting.value = true
 })
 
-// Maps each indicator variant to its dot color. Hoisted out of the lookup
-// function so it isn't reallocated on every render; typed
-// `Record<IndicatorVariant, string>` so extending the union forces a matching
-// entry here. Literal class strings (not interpolated) so Tailwind's JIT
-// compiles them into the shipped stylesheet.
+// Variant → dot color. Literal class strings (not interpolated) so Tailwind's
+// JIT keeps them in the build.
 const INDICATOR_DOT_CLASSES: Record<IndicatorVariant, string> = {
   accent: "bg-accentLight",
   error: "bg-error",
@@ -275,10 +248,8 @@ const INDICATOR_DOT_CLASSES: Record<IndicatorVariant, string> = {
   info: "bg-info",
 }
 
-// Falls back to accent for an undefined or — since Vue doesn't enforce the TS
-// union at runtime — unrecognized `variant`. The own-property check stops
-// inherited keys ("constructor", "__proto__", …) returning a non-string, so the
-// dot always renders a visible color instead of dropping the class.
+// Falls back to accent for an unknown variant (the TS union isn't enforced at
+// runtime); the own-property check avoids inherited keys resolving to non-strings.
 const indicatorDotClass = (variant?: IndicatorVariant): string => {
   const key = variant ?? "accent"
   return Object.prototype.hasOwnProperty.call(INDICATOR_DOT_CLASSES, key)

--- a/src/components/smart/Tabs.vue
+++ b/src/components/smart/Tabs.vue
@@ -24,7 +24,7 @@
               }"
             >
               <button
-                v-for="[tabID, tabMeta] in tabGroup"
+                v-for="([tabID, tabMeta]) in tabGroup"
                 :key="tabID"
                 v-tippy="{
                   theme: 'tooltip',
@@ -99,7 +99,12 @@ import { ref, computed, provide, onBeforeUnmount } from "vue"
  * semantic variants map to feedback colors (e.g. `"error"` flags a tab that
  * needs attention). Optional/undefined falls back to accent for older consumers.
  */
-export type IndicatorVariant = "accent" | "error" | "warning" | "success" | "info"
+export type IndicatorVariant =
+  | "accent"
+  | "error"
+  | "warning"
+  | "success"
+  | "info"
 
 export type TabMeta = {
   label: string | null
@@ -166,11 +171,18 @@ const throwError = (message: string): never => {
 const tabEntries = ref<Array<[string, TabMeta]>>([])
 
 // Resolves a tab's sort weight. `order` is typed `number`, but Vue won't stop a
-// consumer binding a non-finite value at runtime; coerce NaN/±Infinity/undefined
-// to 0 so the comparator stays well-ordered and the registration-index tiebreak
-// still applies.
-const orderOf = (meta: TabMeta): number =>
-  Number.isFinite(meta.order) ? (meta.order as number) : 0
+// consumer passing `order="1"` (a string, an easy slip for `:order="1"`), so we
+// coerce number/string inputs via `Number()`. Everything else hits the early
+// `typeof` guard and maps to 0 without calling `Number()` — covering `undefined`
+// (the unset default) and `Symbol`, whose `Number()` conversion throws. Numeric
+// inputs that coerce to non-finite (non-numeric strings, NaN, ±Infinity) also
+// map to 0, keeping the comparator well-ordered with its index tiebreak.
+const orderOf = (meta: TabMeta): number => {
+  const raw = meta.order
+  if (typeof raw !== "number" && typeof raw !== "string") return 0
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : 0
+}
 
 // Tab related logic — render order respects `tabMeta.order` as a primary
 // sort key, with registration order as a stable tiebreaker. This lets
@@ -263,11 +275,16 @@ const INDICATOR_DOT_CLASSES: Record<IndicatorVariant, string> = {
   info: "bg-info",
 }
 
-// Falls back to the accent class for an undefined or — since Vue doesn't enforce
-// the TS union at runtime — unrecognized `variant`, so the dot always renders a
-// visible color instead of silently dropping the class.
-const indicatorDotClass = (variant?: IndicatorVariant): string =>
-  INDICATOR_DOT_CLASSES[variant ?? "accent"] ?? INDICATOR_DOT_CLASSES.accent
+// Falls back to accent for an undefined or — since Vue doesn't enforce the TS
+// union at runtime — unrecognized `variant`. The own-property check stops
+// inherited keys ("constructor", "__proto__", …) returning a non-string, so the
+// dot always renders a visible color instead of dropping the class.
+const indicatorDotClass = (variant?: IndicatorVariant): string => {
+  const key = variant ?? "accent"
+  return Object.prototype.hasOwnProperty.call(INDICATOR_DOT_CLASSES, key)
+    ? INDICATOR_DOT_CLASSES[key]
+    : INDICATOR_DOT_CLASSES.accent
+}
 
 const selectTab = (id: string) => {
   emit("update:modelValue", id)

--- a/src/stories/Tab.story.vue
+++ b/src/stories/Tab.story.vue
@@ -10,6 +10,74 @@
         </HoppSmartTab>
       </HoppSmartTabs>
     </Variant>
+
+    <Variant title="Indicator variants">
+      <!-- `indicator` shows the dot; `indicator-variant` picks its color. -->
+      <HoppSmartTabs
+        id="indicator-tabs"
+        v-model="indicatorTab"
+        render-inactive-tabs
+      >
+        <HoppSmartTab id="accent" label="Accent" indicator>
+          <h1>Default (accent) dot</h1>
+        </HoppSmartTab>
+        <HoppSmartTab
+          id="error"
+          label="Error"
+          indicator
+          indicator-variant="error"
+        >
+          <h1>Error dot — flags a tab that needs attention</h1>
+        </HoppSmartTab>
+        <HoppSmartTab
+          id="warning"
+          label="Warning"
+          indicator
+          indicator-variant="warning"
+        >
+          <h1>Warning dot</h1>
+        </HoppSmartTab>
+        <HoppSmartTab
+          id="success"
+          label="Success"
+          indicator
+          indicator-variant="success"
+        >
+          <h1>Success dot</h1>
+        </HoppSmartTab>
+        <HoppSmartTab id="info" label="Info" indicator indicator-variant="info">
+          <h1>Info dot</h1>
+        </HoppSmartTab>
+      </HoppSmartTabs>
+    </Variant>
+
+    <Variant title="Ordered">
+      <!--
+        Declared out of order but carrying `order` hints, so they render
+        First / Second / Third. The optional "Pinned" tab toggles via `v-if`
+        yet always lands in slot 2 regardless of mount time — the use case
+        `order` exists for.
+      -->
+      <button @click="showPinned = !showPinned">
+        {{ showPinned ? "Hide pinned tab" : "Show pinned tab" }}
+      </button>
+      <HoppSmartTabs id="ordered-tabs" v-model="orderedTab" render-inactive-tabs>
+        <HoppSmartTab id="third" label="Third" :order="3">
+          <h1>Third content</h1>
+        </HoppSmartTab>
+        <HoppSmartTab id="first" label="First" :order="1">
+          <h1>First content</h1>
+        </HoppSmartTab>
+        <HoppSmartTab
+          v-if="showPinned"
+          id="pinned"
+          label="Pinned (order 2)"
+          :order="2"
+        >
+          <h1>Pinned content</h1>
+        </HoppSmartTab>
+      </HoppSmartTabs>
+    </Variant>
   </Story>
 </template>
 
@@ -18,4 +86,19 @@ import { HoppSmartTabs, HoppSmartTab } from "../components/smart"
 import { ref } from "vue"
 
 const selectedTab = ref("tab1")
+const indicatorTab = ref("error")
+const orderedTab = ref("first")
+const showPinned = ref(false)
 </script>
+
+<style scoped>
+button {
+  margin: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #f5f5f5;
+  cursor: pointer;
+  color: #333;
+}
+</style>

--- a/ui-preset.ts
+++ b/ui-preset.ts
@@ -25,10 +25,9 @@ export default {
         bannerInfo: "var(--banner-info-color)",
         bannerWarning: "var(--banner-warning-color)",
         bannerError: "var(--banner-error-color)",
-        // Semantic feedback colors for inline signals (e.g. tab indicator dots),
-        // themeable via `--feedback-*-color` (@hoppscotch/ui's themes.scss, dark-only).
-        // Literal 500-shade fallbacks keep them working where that stylesheet isn't
-        // loaded; `--feedback-*` avoids colliding with `--status-*`/`--method-*`/`--error-color`.
+        // Inline feedback colors (e.g. tab indicator dots), themed via themes.scss's
+        // `--feedback-*` vars; the literal 500-shade fallbacks render even where that
+        // stylesheet isn't loaded.
         error: "var(--feedback-error-color, #ef4444)",
         warning: "var(--feedback-warning-color, #f59e0b)",
         success: "var(--feedback-success-color, #22c55e)",

--- a/ui-preset.ts
+++ b/ui-preset.ts
@@ -25,12 +25,10 @@ export default {
         bannerInfo: "var(--banner-info-color)",
         bannerWarning: "var(--banner-warning-color)",
         bannerError: "var(--banner-error-color)",
-        // Semantic feedback colors for inline signals — error indicator dots,
-        // validation accents, etc. Themeable via `--feedback-*-color` (defined
-        // in hopp-ui themes.scss, dark-only); the literal fallbacks (Tailwind's
-        // 500 shades) keep them working where that stylesheet isn't loaded.
-        // Named `--feedback-*` to avoid colliding with the platform's
-        // `--status-*` (HTTP response), `--method-*`, and `--error-color` vars.
+        // Semantic feedback colors for inline signals (e.g. tab indicator dots),
+        // themeable via `--feedback-*-color` (@hoppscotch/ui's themes.scss, dark-only).
+        // Literal 500-shade fallbacks keep them working where that stylesheet isn't
+        // loaded; `--feedback-*` avoids colliding with `--status-*`/`--method-*`/`--error-color`.
         error: "var(--feedback-error-color, #ef4444)",
         warning: "var(--feedback-warning-color, #f59e0b)",
         success: "var(--feedback-success-color, #22c55e)",

--- a/ui-preset.ts
+++ b/ui-preset.ts
@@ -25,6 +25,16 @@ export default {
         bannerInfo: "var(--banner-info-color)",
         bannerWarning: "var(--banner-warning-color)",
         bannerError: "var(--banner-error-color)",
+        // Semantic feedback colors for inline signals — error indicator dots,
+        // validation accents, etc. Themeable via `--feedback-*-color` (defined
+        // in hopp-ui themes.scss, dark-only); the literal fallbacks (Tailwind's
+        // 500 shades) keep them working where that stylesheet isn't loaded.
+        // Named `--feedback-*` to avoid colliding with the platform's
+        // `--status-*` (HTTP response), `--method-*`, and `--error-color` vars.
+        error: "var(--feedback-error-color, #ef4444)",
+        warning: "var(--feedback-warning-color, #f59e0b)",
+        success: "var(--feedback-success-color, #22c55e)",
+        info: "var(--feedback-info-color, #3b82f6)",
         tooltip: "var(--tooltip-color)",
         popover: "var(--popover-color)",
         gradientFrom: "var(--gradient-from-color)",


### PR DESCRIPTION
Add an `indicatorVariant` prop to HoppSmartTab that maps the indicator dot to semantic feedback colors (accent | error | warning | success | info) via a shared `IndicatorVariant` type, replacing the need for `:deep()` overrides to recolor the dot. Backed by new error/warning/ success/info tokens in ui-preset.ts that read themeable `--feedback-*` vars (defined dark-only in themes.scss) with literal 500-shade fallbacks so they render even where that stylesheet isn't loaded.

Add an optional `order` prop so consumers can pin a tab's position independent of mount order (useful for tabs toggled via `v-if`); ties resolve by registration order. Defaults to 0 — sort stays stable for tabs that don't opt in.

Both additions are optional and backward compatible.