### PR TITLE
chore: bump version to `0.2.6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/ui",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "MIT",
   "description": "Hoppscotch UI",
   "author": "Hoppscotch (support@hoppscotch.io)",


### PR DESCRIPTION
Includes #41.